### PR TITLE
增加apk版本号设置界面

### DIFF
--- a/httpserver.go
+++ b/httpserver.go
@@ -83,7 +83,21 @@ func newHandler() http.Handler {
 		renderJSON(w, map[string]string{
 			"server":    version,
 			"atx-agent": atxAgentVersion,
+			"uiautomator2": uiautomator2Version,
+			"recorder": recorderVersion,
 		})
+	})
+	r.HandleFunc("/setversion", func(w http.ResponseWriter, r *http.Request) {
+		//renderJSON(w, map[string]string{
+		//	"server":    version,
+		//	"atx-agent": atxAgentVersion,
+		//	"uiautomator2": uiautomator2Version,
+		//	"recorder": recorderVersion,
+		//})
+		renderHTML(w, "setversion.html", map[string]interface{}{
+			"atx":   atxAgentVersion,
+			"uiautomator2": uiautomator2Version,
+			"recorder": recorderVersion})
 	})
 
 	// 设备远程控制

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ import (
 const (
 	version                = "dev"
 	defaultATXAgentVersion = "0.4.3"
+	defaultUIautomatorVersion = "1.1.5"
+	defaultRecorderVersion = "1.0"
 )
 
 var (
@@ -30,7 +32,9 @@ var (
 	rdbAddr         = kingpin.Flag("rdbaddr", "rethinkdb address").Default("localhost:28015").String()
 	rdbName         = kingpin.Flag("rdbname", "rethinkdb database name").Default("atxserver").String()
 	videoBackend    = kingpin.Flag("video-backend", "backend service for encoding images to video").Default("http://localhost:7000").String()
-	atxAgentVersion string
+	//atxAgentVersion string
+	//uiautomator2Version string
+	//recorderVersion string
 	dingtalkToken   string
 )
 
@@ -158,7 +162,9 @@ func batchRunCommand(command string) {
 
 func main() {
 	// Refs: atx-agent version https://github.com/openatx/atx-agent/releases
-	kingpin.Flag("agent", "atx-agent version").Default(defaultATXAgentVersion).StringVar(&atxAgentVersion)
+	//kingpin.Flag("agent", "atx-agent version").Default(defaultATXAgentVersion).StringVar(&atxAgentVersion)
+	//kingpin.Flag("uiautomator2", "uiautomator2 version").Default(defaultUIautomatorVersion).StringVar(&uiautomator2Version)
+	//kingpin.Flag("recorder", "recorder version").Default(defaultRecorderVersion).StringVar(&recorderVersion)
 	// FIXME(ssx): Ding talk is disabled because of too many boring messages
 	kingpin.Flag("ding-token", "DingDing robot token (env: DING_TOKEN)").OverrideDefaultFromEnvar("DING_TOKEN").StringVar(&dingtalkToken)
 	kingpin.Version(version)

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ import (
 const (
 	version                = "dev"
 	defaultATXAgentVersion = "0.4.3"
+	defaultUIautomatorVersion = "1.1.5"
+	defaultRecorderVersion = "1.0"
 )
 
 var (
@@ -31,6 +33,8 @@ var (
 	rdbName         = kingpin.Flag("rdbname", "rethinkdb database name").Default("atxserver").String()
 	videoBackend    = kingpin.Flag("video-backend", "backend service for encoding images to video").Default("http://localhost:7000").String()
 	atxAgentVersion string
+	uiautomator2Version string
+	recorderVersion string
 	dingtalkToken   string
 )
 
@@ -159,6 +163,8 @@ func batchRunCommand(command string) {
 func main() {
 	// Refs: atx-agent version https://github.com/openatx/atx-agent/releases
 	kingpin.Flag("agent", "atx-agent version").Default(defaultATXAgentVersion).StringVar(&atxAgentVersion)
+	kingpin.Flag("uiautomator2", "uiautomator2 version").Default(defaultUIautomatorVersion).StringVar(&uiautomator2Version)
+	kingpin.Flag("recorder", "recorder version").Default(defaultRecorderVersion).StringVar(&recorderVersion)
 	// FIXME(ssx): Ding talk is disabled because of too many boring messages
 	kingpin.Flag("ding-token", "DingDing robot token (env: DING_TOKEN)").OverrideDefaultFromEnvar("DING_TOKEN").StringVar(&dingtalkToken)
 	kingpin.Version(version)

--- a/proto/message.go
+++ b/proto/message.go
@@ -105,6 +105,11 @@ type Provider struct {
 	PresenceChangedAt time.Time    `json:"presenceChangedAt,omitempty"`
 }
 
+type Version struct {
+	ApkType                		 string       `json:"apkType" gorethink:"apkType,omitempty"`
+	VersionNumber                string       `json:"versionNumber" gorethink:"versionNumber,omitempty"`
+}
+
 // Addr combined with ip:port
 func (p *Provider) Addr() string {
 	return fmt.Sprintf("%s:%d", p.IP, p.Port)

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,12 @@
         </li>
         <li>
           <a href="/videos">
-            <i class="fa fa-film"></i> 视频列表</a>
+            <i class="fa fa-film"></i> 视频列表
+          </a>
+        </li>
+        <li>
+          <a href="/setversion"> 版本
+          </a>
         </li>
       </ul>
     </div>

--- a/templates/providers.html
+++ b/templates/providers.html
@@ -56,6 +56,15 @@
                         <i class="fa fa-bandcamp"></i> 节点列表
                     </a>
                 </li>
+                <li>
+                    <a href="/videos">
+                        <i class="fa fa-film"></i> 视频列表
+                    </a>
+                </li>
+                <li>
+                    <a href="/setversion"> 版本
+                    </a>
+                </li>
             </ul>
         </div>
     </nav>

--- a/templates/setversion.html
+++ b/templates/setversion.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.3/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/moment@2.20.1/moment.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.1/dist/clipboard.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/notifyjs-browser@0.4.2/dist/notify.min.js"></script>
+    <style>
+        .color-green {
+            color: green;
+        }
+
+        .cursor {
+            cursor: pointer;
+        }
+    </style>
+</head>
+
+<body>
+<nav class="navbar navbar-default">
+    <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1"
+                aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="/">
+            <b>ATX</b> -
+            <strong>Server</strong>
+        </a>
+    </div>
+    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+        <p class="navbar-text"></p>
+        <ul class="nav navbar-nav">
+            <li class="active">
+                <a href="/">
+                    <i class="fa fa-list-alt"></i> 设备列表
+                </a>
+            </li>
+            <li>
+                <a href="/providers">
+                    <i class="fa fa-bandcamp"></i> 节点列表
+                </a>
+            </li>
+            <li>
+                <a href="/videos">
+                    <i class="fa fa-film"></i> 视频列表
+                </a>
+            </li>
+            <li>
+                <a href="/version"> 版本
+                </a>
+            </li>
+        </ul>
+    </div>
+</nav>
+<div class="container-fluid" id="app">
+    <table class="table">
+        <thead>
+        <tr>
+            <th>apk类型</th>
+            <th>version</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr v-for="p in apkTypes" :key="p.type">
+            <td>{{p.type}}</td>
+            <td @click="updateVersion(p)">{{p.version}} <i class="cursor fa fa-edit"></i></td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<script>
+    var atxVersion = "[[.atx]]"
+    var uiautomatorVersion = "[[.uiautomator2]]"
+    var recorderVersion = "[[.recorder]]"
+    new Vue({
+        el: "#app",
+        data: {
+            apkTypes: [{"type":"atx-agent", "version":atxVersion},
+                {"type":"uiautomator2", "version":uiautomatorVersion},
+                {"type":"recorcer", "version":recorderVersion}],
+        },
+        methods: {
+            updateVersion: function (v) {
+                var newVersion = window.prompt("Version Number", v.version);
+                console.log(newVersion, newVersion == null)
+                if (newVersion === null || newVersion == v.version) {
+                    return
+                }
+                v.version = newVersion;
+                console.log("update version number", v.version)
+                $.ajax({
+                    method: "PUT",
+                    url: "/version/" + v.id,
+                    data: JSON.stringify({
+                        "version": newVersion,
+                    })
+                }).then(function (ret) {
+                    console.log(ret)
+                    v.version = newVersion;
+                }.bind(this))
+            }
+        }
+    })
+</script>
+</body>
+
+</html>

--- a/templates/setversion.html
+++ b/templates/setversion.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="/assets/style.css">
+
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.3/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/moment@2.20.1/moment.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.1/dist/clipboard.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/notifyjs-browser@0.4.2/dist/notify.min.js"></script>
+    <style>
+        .color-green {
+            color: green;
+        }
+
+        .cursor {
+            cursor: pointer;
+        }
+    </style>
+</head>
+
+<body>
+<nav class="navbar navbar-default">
+    <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1"
+                aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="/">
+            <b>ATX</b> -
+            <strong>Server</strong>
+        </a>
+    </div>
+    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+        <p class="navbar-text"></p>
+        <ul class="nav navbar-nav">
+            <li class="active">
+                <a href="/">
+                    <i class="fa fa-list-alt"></i> 设备列表
+                </a>
+            </li>
+            <li>
+                <a href="/providers">
+                    <i class="fa fa-bandcamp"></i> 节点列表
+                </a>
+            </li>
+            <li>
+                <a href="/videos">
+                    <i class="fa fa-film"></i> 视频列表
+                </a>
+            </li>
+            <li>
+                <a href="/setversion"> 版本
+                </a>
+            </li>
+        </ul>
+    </div>
+</nav>
+<div class="container-fluid" id="app">
+    <table class="table">
+        <thead>
+        <tr>
+            <th>apk类型</th>
+            <th>version</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr v-for="p in apkTypes" :key="p.type">
+            <td>{{p.type}}</td>
+            <td @click="updateVersion(p)">{{p.version}} <i class="cursor fa fa-edit"></i></td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<script>
+    var atxVersion = "[[.atx]]"
+    var uiautomatorVersion = "[[.uiautomator2]]"
+    var recorderVersion = "[[.recorder]]"
+    new Vue({
+        el: "#app",
+        data: {
+            apkTypes: [{"type":"atxagent", "version":atxVersion},
+                {"type":"uiautomator2", "version":uiautomatorVersion},
+                {"type":"recorcer", "version":recorderVersion}],
+        },
+        methods: {
+            updateVersion: function (v) {
+                var newVersion = window.prompt("Version Number", v.version);
+                console.log(newVersion, newVersion == null)
+                if (newVersion === null || newVersion == v.version) {
+                    return
+                }
+                v.version = newVersion;
+                console.log("update version number", v.version)
+                $.ajax({
+                    method: "PUT",
+                    url: "/version/" + v.type,
+                    data: JSON.stringify({
+                        "ApkType": v.type,
+                        "VersionNumber": newVersion,
+                    })
+                }).then(function (ret) {
+                    console.log(ret)
+                    v.version = newVersion;
+                }.bind(this))
+            }
+        }
+    })
+</script>
+</body>
+
+</html>


### PR DESCRIPTION
在导航栏中增加《版本》分页，用于设置依赖apk的版本号并存进rethinkdb，后期查询会从rethinkdb中获取版本号。